### PR TITLE
20170514 New Feature / Speedup: Center cropping

### DIFF
--- a/source/cls/clsTasks.vb
+++ b/source/cls/clsTasks.vb
@@ -1037,6 +1037,23 @@ dBug:
 
     End Function
 
+    Public Function images_Combine_centered(ByVal imgBack As Image, ByVal imgFront As Image) As Image
+        'this can now combine images of any size and will center them on each other
+
+        Dim x_max As UShort = Math.Max(imgBack.Width, imgFront.Width)
+        Dim y_max As UShort = Math.Max(imgBack.Height, imgFront.Height)
+
+        Dim bmp As New Bitmap(x_max, y_max)
+        Dim g As Graphics = Graphics.FromImage(bmp)
+
+        g.InterpolationMode = Drawing2D.InterpolationMode.NearestNeighbor ' prevent softening
+        g.DrawImage(imgBack, CInt((x_max - imgBack.Width) / 2), CInt((y_max - imgBack.Height) / 2), imgBack.Width, imgBack.Height)
+        g.DrawImage(imgFront, CInt((x_max - imgFront.Width) / 2), CInt((y_max - imgFront.Height) / 2), imgFront.Width, imgFront.Height)
+        g.Dispose()
+        Return bmp
+
+    End Function
+
     Public Function images_Combine(ByVal imgBack As Image, ByVal imgFront As Image) As Image
 
         Dim bmp As New Bitmap(imgBack.Width, imgBack.Height)

--- a/source/forms/frmSettings.vb
+++ b/source/forms/frmSettings.vb
@@ -21,6 +21,7 @@ Public Class frmSettings
             .Add("Keep canvas size (" & cfg_grid_numPixels & " x " & cfg_grid_numPixels & ")")
             .Add("Crop to largest relevant width / height in this graphic")
             .Add("Crop to relevant pixels of this frame")
+            .Add("Crop around center (fast but experimental)")
         End With
 
         ' Paths


### PR DESCRIPTION
Oooh, this time the comparison seems to work for some reason! Anyway, I had already typed these out so here are my changes:

frmSettings.vb
-added case 3: .Add("Crop around center (fast but experimental)")

clsFrame2.vb
-extended "Select Case cfg_export_PNG_CanvasSize" by case 3
-new function: getCoreImageBitmap_centered()
(only pads as much as required to keep the image centered)
-new function: getImage_centered()
(the same as normal, just uses getCoreImageBitmap_centered() and images_Combine_centered() instead of the original versions)

clsTasks.vb
-new function: images_Combine_centered()
(will merge images of any size centered relative to the bigger input)

Seems to work perfectly as far as I can tell, I tested with background and extra graphics.
This should be a significant speedup. None of the output goes through the getDefiningRectangle stuff!