### PR TITLE
20170630 Fixes: Commandline

### DIFF
--- a/source/cls/clsTasks.vb
+++ b/source/cls/clsTasks.vb
@@ -832,7 +832,9 @@ dBug:
 
             'Debug.Print("Convert file PNG to ZT1: " & f)
             clsTasks.convert_file_PNG_to_ZT1(f, False)
-            PB.Value += 1
+            If IsNothing(PB) = False Then
+                PB.Value += 1
+            End If
 
             Application.DoEvents()
 
@@ -1795,7 +1797,7 @@ dBug:
         ' See which action was specified. 
         ' We do this now because users might quickly change the order of arguments. 
         ' Eg if they say  ZTStudio.exe /convertFolder:<path> /ZTAF:1 instead of /ZTAF:1 /convertFolder:<path>, they might not get the right result.
-        Select Case vbNullString
+        Select Case strArgAction
 
             Case "convertfile.topng"
                 ' Do conversion.


### PR DESCRIPTION
I tried to make my blender script work with the current ZT studio. I found and fixed two issues:
1) command line actions were ignored as it interpreted a vbNullstring instead of the argument
2) updating the nonexisting Progress bar in command line batch mode crashed
It still doesn't work properly for some reason, but at least it does something